### PR TITLE
[FEATURE] - Game Stats Page

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "private": true,
   "sideEffects": false,
+  "version": "0.1.0",
   "scripts": {
     "build": "remix build",
     "dev": "remix dev"

--- a/src/Layout/index.tsx
+++ b/src/Layout/index.tsx
@@ -7,7 +7,7 @@ export default function Layout({ children }: PropsWithChildren) {
   return (
     <>
       <Header />
-      <Container maxWidth="xl" sx={{ paddingTop: '2em' }}>
+      <Container maxWidth="xl" sx={{ padding: '2em 0' }}>
         {children}
       </Container>
       <Footer />

--- a/src/css/stats-styles.css
+++ b/src/css/stats-styles.css
@@ -1,0 +1,18 @@
+.stats-wrapper {
+  box-shadow: 0px 0px 15px lightgray;
+  padding: 2rem;
+}
+
+.stat-title {
+  padding-right: 0.5rem;
+}
+
+.team-stats-container {
+  padding-top: 2rem;
+}
+
+.stat-row {
+  overflow-x: scroll;
+  white-space: nowrap;
+  width: 100%;
+}

--- a/src/pages/GameStats/components/TeamLeaderContainer.tsx
+++ b/src/pages/GameStats/components/TeamLeaderContainer.tsx
@@ -3,8 +3,10 @@ import { LeadingStatsData } from 'utilities/api/types'
 
 export function TeamLeaderContainer({
   leadingStats,
+  teamType,
 }: {
   leadingStats?: LeadingStatsData
+  teamType: 'Home' | 'Away'
 }) {
   return (
     <Box
@@ -14,6 +16,7 @@ export function TeamLeaderContainer({
       rowGap="1rem"
       className="team-lead"
     >
+      <Typography variant="h6">{teamType}</Typography>
       <Typography variant="h3">{leadingStats?.team.full_name}</Typography>
       <Typography variant="subtitle1">Leading Scorer</Typography>
       <Typography variant="h5">{leadingStats?.player.full_name}</Typography>

--- a/src/pages/GameStats/components/TeamLeaderContainer.tsx
+++ b/src/pages/GameStats/components/TeamLeaderContainer.tsx
@@ -1,0 +1,42 @@
+import { Box, Typography } from '@mui/material'
+import { LeadingStatsData } from 'utilities/api/types'
+
+export function TeamLeaderContainer({
+  leadingStats,
+}: {
+  leadingStats?: LeadingStatsData
+}) {
+  return (
+    <Box
+      display="flex"
+      flexDirection="column"
+      alignItems="center"
+      rowGap="1rem"
+      className="team-lead"
+    >
+      <Typography variant="h3">{leadingStats?.team.full_name}</Typography>
+      <Typography variant="subtitle1">Leading Scorer</Typography>
+      <Typography variant="h5">{leadingStats?.player.full_name}</Typography>
+      <Box display="flex" columnGap="1.5rem">
+        <Typography sx={{ fontSize: 16 }} color="text.secondary" gutterBottom>
+          <span>
+            <strong className="stat-title">Points:</strong>
+            {leadingStats?.pts}
+          </span>
+        </Typography>
+        <Typography sx={{ fontSize: 16 }} color="text.secondary" gutterBottom>
+          <span>
+            <strong className="stat-title">Rebounds:</strong>
+            {leadingStats?.reb}
+          </span>
+        </Typography>
+        <Typography sx={{ fontSize: 16 }} color="text.secondary" gutterBottom>
+          <span>
+            <strong className="stat-title">Assists:</strong>
+            {leadingStats?.ast}
+          </span>
+        </Typography>
+      </Box>
+    </Box>
+  )
+}

--- a/src/pages/GameStats/components/TeamStatsContainer.tsx
+++ b/src/pages/GameStats/components/TeamStatsContainer.tsx
@@ -1,0 +1,86 @@
+import { Box, Typography } from '@mui/material'
+import { StatsData, TeamStats } from 'utilities/api/types'
+
+export function TeamStatsContainer({ teamStats }: { teamStats?: TeamStats }) {
+  const sortPlayerStats = (stats: StatsData) => {
+    const mainStats = Object.keys(stats).filter((key) =>
+      key.match(/ast|pts|reb/)
+    )
+    const remainingStats = Object.keys(stats).filter(
+      (key) => !key.match(/ast|pts|reb/)
+    )
+
+    return [...mainStats, ...remainingStats].filter(
+      (key) => !key.match(/Id|id/) && !key.match(/game|player|team/)
+    )
+  }
+
+  const renderStat = (stat: string) => {
+    const numberStat = Number.parseFloat(stat)
+
+    if (numberStat) {
+      if (numberStat % 1 != 0) {
+        return `${Math.round(numberStat * 100 * 100) / 100}%`
+      }
+
+      return numberStat
+    }
+
+    return stat
+  }
+
+  return (
+    <Box display="flex" flexDirection="column" className="team-stats-container">
+      <Typography variant="h6" padding="2rem">
+        {teamStats?.leadingStats?.team.name}
+      </Typography>
+      <Box
+        display="flex"
+        flexDirection="column"
+        className="team-1-stats"
+        alignItems="start"
+        rowGap="1.5rem"
+        width="100%"
+      >
+        {teamStats?.stats.map((playerStats) => (
+          <Box
+            key={playerStats.player.id}
+            display="flex"
+            padding="0.5rem"
+            columnGap="2rem"
+            borderTop="1px solid black"
+            borderBottom="1px solid black"
+            width="100%"
+            whiteSpace="nowrap"
+            overflow="hidden"
+          >
+            <Typography
+              sx={{ fontSize: 16 }}
+              color="text.secondary"
+              gutterBottom
+            >
+              {playerStats.player.full_name} | {playerStats.player.position}
+            </Typography>
+            <Box
+              display="flex"
+              className="stat-row"
+              columnGap="4rem"
+              flexShrink="0"
+            >
+              {sortPlayerStats(playerStats).map((statName) => (
+                <Box key={statName} display="flex" flexDirection="column">
+                  <Typography variant="subtitle2" paddingBottom="0.5rem">
+                    {statName.toUpperCase()}
+                  </Typography>
+                  <Typography variant="body1">
+                    {renderStat(playerStats[statName])}
+                  </Typography>
+                </Box>
+              ))}
+            </Box>
+          </Box>
+        ))}
+      </Box>
+    </Box>
+  )
+}

--- a/src/pages/GameStats/index.tsx
+++ b/src/pages/GameStats/index.tsx
@@ -40,7 +40,10 @@ export function GameStats() {
               justifyContent="space-evenly"
               width="100%"
             >
-              <TeamLeaderContainer leadingStats={homeTeamStats?.leadingStats} />
+              <TeamLeaderContainer
+                teamType="Home"
+                leadingStats={homeTeamStats?.leadingStats}
+              />
               <Box
                 display="flex"
                 flexDirection="column"
@@ -61,10 +64,19 @@ export function GameStats() {
                   color="text.primary"
                   gutterBottom
                 >
-                  {gameStats?.status}
+                  {gameStats?.status} - {gameStats.time.split(' ').pop()}
+                </Typography>
+                <Typography
+                  variant="h5"
+                  color="text.primary"
+                  paddingTop="1.5rem"
+                  gutterBottom
+                >
+                  {gameStats?.home_team_score} - {gameStats.visitor_team_score}
                 </Typography>
               </Box>
               <TeamLeaderContainer
+                teamType="Away"
                 leadingStats={visitorTeamStats?.leadingStats}
               />
             </Box>

--- a/src/pages/GameStats/index.tsx
+++ b/src/pages/GameStats/index.tsx
@@ -2,14 +2,15 @@ import { useLoaderData, useRevalidator } from '@remix-run/react'
 import { useEffect } from 'react'
 import { GameStatsLoaderData } from './loader'
 
-import { Box } from '@mui/material'
+import Box from '@mui/material/Box'
+import Typography from '@mui/material/Typography'
 
 export function GameStats() {
-  const { gameStats } = useLoaderData<GameStatsLoaderData>()
+  const { gameStats, homeTeamStats, visitorTeamStats } =
+    useLoaderData<GameStatsLoaderData>()
   const revalidator = useRevalidator()
 
   useEffect(() => {
-    console.table(gameStats)
     const refreshInterval = setInterval(() => {
       if (revalidator.state === 'idle') {
         revalidator.revalidate()
@@ -19,5 +20,246 @@ export function GameStats() {
     return () => clearInterval(refreshInterval)
   }, [])
 
-  return <Box>Will code game stats components later</Box>
+  return (
+    <Box display="flex" flexDirection="column" className="stats-wrapper">
+      <Box
+        display="flex"
+        justifyContent="center"
+        alignItems="center"
+        columnGap="1.5rem"
+      >
+        <Typography sx={{ fontSize: 16 }} color="text.secondary" gutterBottom>
+          {gameStats?.date}
+        </Typography>
+        <Typography variant="subtitle1" color="text.primary" gutterBottom>
+          {gameStats?.status}
+        </Typography>
+      </Box>
+      <Box
+        display="flex"
+        justifyContent="space-evenly"
+        className="game-container"
+        paddingTop="1rem"
+        alignItems="center"
+      >
+        <Box
+          display="flex"
+          flexDirection="column"
+          alignItems="center"
+          rowGap="1rem"
+          className="home-team-lead"
+        >
+          <Typography variant="h3">
+            {homeTeamStats?.leadingStats?.team.full_name}
+          </Typography>
+          <Typography variant="subtitle1">Leading Scorer</Typography>
+          <Typography variant="h5">
+            {homeTeamStats?.leadingStats?.player.full_name}
+          </Typography>
+          <Box display="flex" columnGap="1.5rem">
+            <Typography
+              sx={{ fontSize: 16 }}
+              color="text.secondary"
+              gutterBottom
+            >
+              <span>
+                <strong className="stat-title">Points:</strong>
+                {homeTeamStats?.leadingStats?.pts}
+              </span>
+            </Typography>
+            <Typography
+              sx={{ fontSize: 16 }}
+              color="text.secondary"
+              gutterBottom
+            >
+              <span>
+                <strong className="stat-title">Rebounds:</strong>
+                {homeTeamStats?.leadingStats?.reb}
+              </span>
+            </Typography>
+            <Typography
+              sx={{ fontSize: 16 }}
+              color="text.secondary"
+              gutterBottom
+            >
+              <span>
+                <strong className="stat-title">Assists:</strong>
+                {homeTeamStats?.leadingStats?.ast}
+              </span>
+            </Typography>
+          </Box>
+        </Box>
+        <Typography>@</Typography>
+        <Box
+          display="flex"
+          flexDirection="column"
+          alignItems="center"
+          rowGap="1rem"
+          className="visitor-team-lead"
+        >
+          <Typography variant="h3">
+            {visitorTeamStats?.leadingStats?.team.full_name}
+          </Typography>
+          <Typography variant="subtitle1">Leading Scorer</Typography>
+          <Typography variant="h5">
+            {visitorTeamStats?.leadingStats?.player.full_name}
+          </Typography>
+          <Box display="flex" columnGap="1.5rem">
+            <Typography
+              sx={{ fontSize: 16 }}
+              color="text.secondary"
+              gutterBottom
+            >
+              <span>
+                <strong className="stat-title">Points:</strong>
+                {visitorTeamStats?.leadingStats?.pts}
+              </span>
+            </Typography>
+            <Typography
+              sx={{ fontSize: 16 }}
+              color="text.secondary"
+              gutterBottom
+            >
+              <span>
+                <strong className="stat-title">Rebounds:</strong>
+                {visitorTeamStats?.leadingStats?.reb}
+              </span>
+            </Typography>
+            <Typography
+              sx={{ fontSize: 16 }}
+              color="text.secondary"
+              gutterBottom
+            >
+              <span>
+                <strong className="stat-title">Assists:</strong>
+                {visitorTeamStats?.leadingStats?.ast}
+              </span>
+            </Typography>
+          </Box>
+        </Box>
+      </Box>
+      <Box
+        display="flex"
+        flexDirection="column"
+        className="team-stats-container"
+      >
+        <Typography variant="h6" padding="2rem">
+          {homeTeamStats?.leadingStats?.team.name}
+        </Typography>
+        <Box
+          display="flex"
+          flexDirection="column"
+          className="team-1-stats"
+          alignItems="start"
+          rowGap="1.5rem"
+          width="100%"
+        >
+          {homeTeamStats?.stats.map((stat) => (
+            <Box
+              key={stat.player.id}
+              display="flex"
+              padding="0.5rem"
+              columnGap="2rem"
+              borderTop="1px solid black"
+              borderBottom="1px solid black"
+              width="100%"
+              whiteSpace="nowrap"
+              overflow="hidden"
+            >
+              <Typography
+                sx={{ fontSize: 16 }}
+                color="text.secondary"
+                gutterBottom
+              >
+                {stat.player.full_name} | {stat.player.position}
+              </Typography>
+              <Box
+                display="flex"
+                className="stat-row"
+                columnGap="0.5rem"
+                flexShrink="0"
+              >
+                {Object.keys(stat).map((statName) => {
+                  if (
+                    statName !== 'game' &&
+                    statName !== 'player' &&
+                    statName !== 'team' &&
+                    !statName.match(/[Id|id]/)
+                  ) {
+                    return (
+                      <span key={statName}>
+                        {statName} - {stat[statName]}
+                      </span>
+                    )
+                  }
+                  return null
+                })}
+              </Box>
+            </Box>
+          ))}
+        </Box>
+      </Box>
+      <Box
+        display="flex"
+        flexDirection="column"
+        className="team-stats-container"
+      >
+        <Typography variant="h6" padding="2rem">
+          {visitorTeamStats?.leadingStats?.team.name}
+        </Typography>
+        <Box
+          display="flex"
+          flexDirection="column"
+          className="team-2-stats"
+          alignItems="start"
+          rowGap="1.5rem"
+          width="100%"
+        >
+          {visitorTeamStats?.stats.map((stat) => (
+            <Box
+              key={stat.player.id}
+              display="flex"
+              padding="0.5rem"
+              columnGap="2rem"
+              borderTop="1px solid black"
+              borderBottom="1px solid black"
+              width="100%"
+              whiteSpace="nowrap"
+              overflow="hidden"
+            >
+              <Typography
+                sx={{ fontSize: 16 }}
+                color="text.secondary"
+                gutterBottom
+              >
+                {stat.player.full_name} | {stat.player.position}
+              </Typography>
+              <Box
+                display="flex"
+                className="stat-row"
+                columnGap="0.5rem"
+                flexShrink="0"
+              >
+                {Object.keys(stat).map((statName) => {
+                  if (
+                    statName !== 'game' &&
+                    statName !== 'player' &&
+                    statName !== 'team' &&
+                    !statName.match(/[Id|id]/)
+                  ) {
+                    return (
+                      <span key={statName}>
+                        {statName} - {stat[statName]}
+                      </span>
+                    )
+                  }
+                  return null
+                })}
+              </Box>
+            </Box>
+          ))}
+        </Box>
+      </Box>
+    </Box>
+  )
 }

--- a/src/pages/GameStats/index.tsx
+++ b/src/pages/GameStats/index.tsx
@@ -4,6 +4,8 @@ import { GameStatsLoaderData } from './loader'
 
 import Box from '@mui/material/Box'
 import Typography from '@mui/material/Typography'
+import { TeamLeaderContainer } from './components/TeamLeaderContainer'
+import { TeamStatsContainer } from './components/TeamStatsContainer'
 
 export function GameStats() {
   const { gameStats, homeTeamStats, visitorTeamStats } =
@@ -22,244 +24,68 @@ export function GameStats() {
 
   return (
     <Box display="flex" flexDirection="column" className="stats-wrapper">
-      <Box
-        display="flex"
-        justifyContent="center"
-        alignItems="center"
-        columnGap="1.5rem"
-      >
-        <Typography sx={{ fontSize: 16 }} color="text.secondary" gutterBottom>
-          {gameStats?.date}
-        </Typography>
-        <Typography variant="subtitle1" color="text.primary" gutterBottom>
-          {gameStats?.status}
-        </Typography>
-      </Box>
-      <Box
-        display="flex"
-        justifyContent="space-evenly"
-        className="game-container"
-        paddingTop="1rem"
-        alignItems="center"
-      >
-        <Box
-          display="flex"
-          flexDirection="column"
-          alignItems="center"
-          rowGap="1rem"
-          className="home-team-lead"
-        >
-          <Typography variant="h3">
-            {homeTeamStats?.leadingStats?.team.full_name}
-          </Typography>
-          <Typography variant="subtitle1">Leading Scorer</Typography>
-          <Typography variant="h5">
-            {homeTeamStats?.leadingStats?.player.full_name}
-          </Typography>
-          <Box display="flex" columnGap="1.5rem">
-            <Typography
-              sx={{ fontSize: 16 }}
-              color="text.secondary"
-              gutterBottom
-            >
-              <span>
-                <strong className="stat-title">Points:</strong>
-                {homeTeamStats?.leadingStats?.pts}
-              </span>
-            </Typography>
-            <Typography
-              sx={{ fontSize: 16 }}
-              color="text.secondary"
-              gutterBottom
-            >
-              <span>
-                <strong className="stat-title">Rebounds:</strong>
-                {homeTeamStats?.leadingStats?.reb}
-              </span>
-            </Typography>
-            <Typography
-              sx={{ fontSize: 16 }}
-              color="text.secondary"
-              gutterBottom
-            >
-              <span>
-                <strong className="stat-title">Assists:</strong>
-                {homeTeamStats?.leadingStats?.ast}
-              </span>
-            </Typography>
-          </Box>
-        </Box>
-        <Typography>@</Typography>
-        <Box
-          display="flex"
-          flexDirection="column"
-          alignItems="center"
-          rowGap="1rem"
-          className="visitor-team-lead"
-        >
-          <Typography variant="h3">
-            {visitorTeamStats?.leadingStats?.team.full_name}
-          </Typography>
-          <Typography variant="subtitle1">Leading Scorer</Typography>
-          <Typography variant="h5">
-            {visitorTeamStats?.leadingStats?.player.full_name}
-          </Typography>
-          <Box display="flex" columnGap="1.5rem">
-            <Typography
-              sx={{ fontSize: 16 }}
-              color="text.secondary"
-              gutterBottom
-            >
-              <span>
-                <strong className="stat-title">Points:</strong>
-                {visitorTeamStats?.leadingStats?.pts}
-              </span>
-            </Typography>
-            <Typography
-              sx={{ fontSize: 16 }}
-              color="text.secondary"
-              gutterBottom
-            >
-              <span>
-                <strong className="stat-title">Rebounds:</strong>
-                {visitorTeamStats?.leadingStats?.reb}
-              </span>
-            </Typography>
-            <Typography
-              sx={{ fontSize: 16 }}
-              color="text.secondary"
-              gutterBottom
-            >
-              <span>
-                <strong className="stat-title">Assists:</strong>
-                {visitorTeamStats?.leadingStats?.ast}
-              </span>
-            </Typography>
-          </Box>
-        </Box>
-      </Box>
-      <Box
-        display="flex"
-        flexDirection="column"
-        className="team-stats-container"
-      >
-        <Typography variant="h6" padding="2rem">
-          {homeTeamStats?.leadingStats?.team.name}
-        </Typography>
-        <Box
-          display="flex"
-          flexDirection="column"
-          className="team-1-stats"
-          alignItems="start"
-          rowGap="1.5rem"
-          width="100%"
-        >
-          {homeTeamStats?.stats.map((stat) => (
+      {gameStats ? (
+        <Box>
+          <Box
+            display="flex"
+            flexDirection="column"
+            className="game-container"
+            paddingTop="1rem"
+            alignItems="center"
+          >
             <Box
-              key={stat.player.id}
               display="flex"
-              padding="0.5rem"
-              columnGap="2rem"
-              borderTop="1px solid black"
-              borderBottom="1px solid black"
+              paddingTop="1rem"
+              alignItems="center"
+              justifyContent="space-evenly"
               width="100%"
-              whiteSpace="nowrap"
-              overflow="hidden"
             >
-              <Typography
-                sx={{ fontSize: 16 }}
-                color="text.secondary"
-                gutterBottom
-              >
-                {stat.player.full_name} | {stat.player.position}
-              </Typography>
+              <TeamLeaderContainer leadingStats={homeTeamStats?.leadingStats} />
               <Box
                 display="flex"
-                className="stat-row"
-                columnGap="0.5rem"
-                flexShrink="0"
+                flexDirection="column"
+                className="game-container"
+                paddingTop="1rem"
+                alignItems="center"
               >
-                {Object.keys(stat).map((statName) => {
-                  if (
-                    statName !== 'game' &&
-                    statName !== 'player' &&
-                    statName !== 'team' &&
-                    !statName.match(/[Id|id]/)
-                  ) {
-                    return (
-                      <span key={statName}>
-                        {statName} - {stat[statName]}
-                      </span>
-                    )
-                  }
-                  return null
-                })}
+                <Typography
+                  sx={{ fontSize: 16 }}
+                  color="text.secondary"
+                  gutterBottom
+                >
+                  {gameStats?.date}
+                </Typography>
+                <Typography>@</Typography>
+                <Typography
+                  variant="subtitle1"
+                  color="text.primary"
+                  gutterBottom
+                >
+                  {gameStats?.status}
+                </Typography>
               </Box>
+              <TeamLeaderContainer
+                leadingStats={visitorTeamStats?.leadingStats}
+              />
             </Box>
-          ))}
+          </Box>
+          <TeamStatsContainer teamStats={homeTeamStats} />
+          <TeamStatsContainer teamStats={visitorTeamStats} />
         </Box>
-      </Box>
-      <Box
-        display="flex"
-        flexDirection="column"
-        className="team-stats-container"
-      >
-        <Typography variant="h6" padding="2rem">
-          {visitorTeamStats?.leadingStats?.team.name}
-        </Typography>
+      ) : (
         <Box
           display="flex"
           flexDirection="column"
-          className="team-2-stats"
-          alignItems="start"
-          rowGap="1.5rem"
-          width="100%"
+          rowGap="4rem"
+          justifyContent="center"
+          alignItems="center"
         >
-          {visitorTeamStats?.stats.map((stat) => (
-            <Box
-              key={stat.player.id}
-              display="flex"
-              padding="0.5rem"
-              columnGap="2rem"
-              borderTop="1px solid black"
-              borderBottom="1px solid black"
-              width="100%"
-              whiteSpace="nowrap"
-              overflow="hidden"
-            >
-              <Typography
-                sx={{ fontSize: 16 }}
-                color="text.secondary"
-                gutterBottom
-              >
-                {stat.player.full_name} | {stat.player.position}
-              </Typography>
-              <Box
-                display="flex"
-                className="stat-row"
-                columnGap="0.5rem"
-                flexShrink="0"
-              >
-                {Object.keys(stat).map((statName) => {
-                  if (
-                    statName !== 'game' &&
-                    statName !== 'player' &&
-                    statName !== 'team' &&
-                    !statName.match(/[Id|id]/)
-                  ) {
-                    return (
-                      <span key={statName}>
-                        {statName} - {stat[statName]}
-                      </span>
-                    )
-                  }
-                  return null
-                })}
-              </Box>
-            </Box>
-          ))}
+          <Typography variant="h3">No Stats Available</Typography>
+          <Typography variant="subtitle2" fontSize="16px">
+            Wait for game to start...
+          </Typography>
         </Box>
-      </Box>
+      )}
     </Box>
   )
 }

--- a/src/pages/GameStats/index.tsx
+++ b/src/pages/GameStats/index.tsx
@@ -6,6 +6,7 @@ import Box from '@mui/material/Box'
 import Typography from '@mui/material/Typography'
 import { TeamLeaderContainer } from './components/TeamLeaderContainer'
 import { TeamStatsContainer } from './components/TeamStatsContainer'
+import { isTime } from 'utilities/api/service'
 
 export function GameStats() {
   const { gameStats, homeTeamStats, visitorTeamStats } =
@@ -64,7 +65,8 @@ export function GameStats() {
                   color="text.primary"
                   gutterBottom
                 >
-                  {gameStats?.status} - {gameStats.time.split(' ').pop()}
+                  {gameStats?.status}{' '}
+                  {isTime(gameStats.time) && `- ${gameStats.time}`}
                 </Typography>
                 <Typography
                   variant="h5"

--- a/src/pages/GameStats/loader.ts
+++ b/src/pages/GameStats/loader.ts
@@ -1,5 +1,3 @@
-import { GameStatus } from 'utilities/api/types'
-
 import { json } from '@remix-run/server-runtime'
 import { getGameStats } from 'utilities/api/service'
 import { LoaderArgs, SerializeFrom } from '@remix-run/node'
@@ -9,9 +7,15 @@ export type GameStatsLoaderData = SerializeFrom<typeof loader>
 export const loader = async ({ params }: LoaderArgs) => {
   const { gameId } = params
 
-  const gameStats = await getGameStats(gameId)
+  const gameStatsResponse = await getGameStats(gameId)
+
+  const gameStats = gameStatsResponse.data?.home_team.stats[0].game
+  const homeTeamStats = gameStatsResponse.data?.home_team
+  const visitorTeamStats = gameStatsResponse.data?.visitor_team
 
   return json({
     gameStats,
+    homeTeamStats,
+    visitorTeamStats,
   })
 }

--- a/src/pages/Home/components/games-card-carousel.tsx
+++ b/src/pages/Home/components/games-card-carousel.tsx
@@ -63,7 +63,7 @@ export const GamesCardCarousel = ({
                   color="text.primary"
                   gutterBottom
                 >
-                  {game.status}
+                  {game.status} - {game.time.split(' ').pop()}
                 </Typography>
               </Box>
               <Box

--- a/src/pages/Home/components/games-card-carousel.tsx
+++ b/src/pages/Home/components/games-card-carousel.tsx
@@ -13,6 +13,7 @@ import type { CardCarouselProps } from '~/components/card-carousel'
 
 import type { GamesDTO } from 'utilities/api/dtos'
 import { useNavigate } from '@remix-run/react'
+import { isTime } from 'utilities/api/service'
 
 type GamesCardCarouselProps = Omit<
   CardCarouselProps,
@@ -63,7 +64,7 @@ export const GamesCardCarousel = ({
                   color="text.primary"
                   gutterBottom
                 >
-                  {game.status} - {game.time.split(' ').pop()}
+                  {game.status} {isTime(game.time) && `- ${game.time}`}
                 </Typography>
               </Box>
               <Box

--- a/src/pages/Home/components/scheduled-games-title.tsx
+++ b/src/pages/Home/components/scheduled-games-title.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 
 import { useSearchParams } from '@remix-run/react'
 
@@ -13,16 +13,25 @@ import { dateFormat } from 'utilities/constants/date-constants'
 
 type ScheduledGamesTitleProps = { season: string }
 
-const today = dayjs().format(dateFormat)
-
 export const ScheduledGamesTitle = ({ season }: ScheduledGamesTitleProps) => {
   const [search, setSearch] = useSearchParams()
   const [dates, setDates] = useState({
-    startDate: search.get('startDate') || today,
-    endDate: search.get('endDate') || dayjs().add(1, 'week').format(dateFormat),
+    startDate: search.get('startDate'),
+    endDate: search.get('endDate'),
   })
 
-  const [isLive, setIsLive] = useState(dates.startDate === today)
+  const [isLive, setIsLive] = useState(false)
+
+  let today: string | null
+
+  // This is necessary to ensure we set "today" based on clients local time.
+  if (typeof document !== 'undefined') {
+    today = dayjs().format(dateFormat)
+  }
+
+  useEffect(() => {
+    setIsLive(dates.startDate === today)
+  }, [])
 
   return (
     <LocalizationProvider dateAdapter={AdapterDayjs}>
@@ -41,7 +50,7 @@ export const ScheduledGamesTitle = ({ season }: ScheduledGamesTitleProps) => {
             onClick={() => {
               setDates({ ...dates, startDate: today })
               setIsLive(true)
-              search.set('startDate', today)
+              search.set('startDate', String(today))
               setSearch(search, { replace: true })
             }}
           >

--- a/src/pages/Home/components/scheduled-games-title.tsx
+++ b/src/pages/Home/components/scheduled-games-title.tsx
@@ -22,6 +22,8 @@ export const ScheduledGamesTitle = ({ season }: ScheduledGamesTitleProps) => {
     endDate: search.get('endDate') || dayjs().add(1, 'week').format(dateFormat),
   })
 
+  const [isLive, setIsLive] = useState(dates.startDate === today)
+
   return (
     <LocalizationProvider dateAdapter={AdapterDayjs}>
       <Box display="flex" alignItems="center" justifyContent="space-between">
@@ -35,9 +37,10 @@ export const ScheduledGamesTitle = ({ season }: ScheduledGamesTitleProps) => {
         <Box display="flex" columnGap="1rem">
           <Button
             variant="text"
-            sx={{ color: 'red' }}
+            sx={{ color: isLive ? 'red' : 'gray' }}
             onClick={() => {
               setDates({ ...dates, startDate: today })
+              setIsLive(true)
               search.set('startDate', today)
               setSearch(search, { replace: true })
             }}
@@ -55,6 +58,7 @@ export const ScheduledGamesTitle = ({ season }: ScheduledGamesTitleProps) => {
               const selectedDate = dayjs(String(value)).format(dateFormat)
 
               setDates({ ...dates, startDate: selectedDate })
+              setIsLive(selectedDate === today)
               search.set('startDate', selectedDate)
               setSearch(search, { replace: true })
             }}

--- a/src/pages/Home/components/scheduled-games-title.tsx
+++ b/src/pages/Home/components/scheduled-games-title.tsx
@@ -2,22 +2,23 @@ import { useState } from 'react'
 
 import { useSearchParams } from '@remix-run/react'
 
-import { Box, TextField, Typography } from '@mui/material'
+import { Box, Button, TextField, Typography } from '@mui/material'
 
 import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider'
 import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs'
 import { DatePicker } from '@mui/x-date-pickers/DatePicker'
 
 import dayjs from 'dayjs'
+import { dateFormat } from 'utilities/constants/date-constants'
 
 type ScheduledGamesTitleProps = { season: string }
 
-const dateFormat = 'YYYY-MM-DD'
+const today = dayjs().format(dateFormat)
 
 export const ScheduledGamesTitle = ({ season }: ScheduledGamesTitleProps) => {
   const [search, setSearch] = useSearchParams()
   const [dates, setDates] = useState({
-    startDate: search.get('startDate') || dayjs().format(dateFormat),
+    startDate: search.get('startDate') || today,
     endDate: search.get('endDate') || dayjs().add(1, 'week').format(dateFormat),
   })
 
@@ -32,6 +33,17 @@ export const ScheduledGamesTitle = ({ season }: ScheduledGamesTitleProps) => {
           Scheduled Games
         </Typography>
         <Box display="flex" columnGap="1rem">
+          <Button
+            variant="text"
+            sx={{ color: 'red' }}
+            onClick={() => {
+              setDates({ ...dates, startDate: today })
+              search.set('startDate', today)
+              setSearch(search, { replace: true })
+            }}
+          >
+            LIVE
+          </Button>
           <DatePicker
             views={['day']}
             label="Start Date"

--- a/src/pages/Home/index.tsx
+++ b/src/pages/Home/index.tsx
@@ -1,4 +1,8 @@
-import { useLoaderData, useRevalidator } from '@remix-run/react'
+import {
+  useLoaderData,
+  useRevalidator,
+  useSearchParams,
+} from '@remix-run/react'
 import { useEffect } from 'react'
 import { HomeLoaderData } from './loader'
 
@@ -7,13 +11,22 @@ import { ScheduledGamesTitle } from './components/scheduled-games-title'
 
 import { Box } from '@mui/material'
 import dayjs from 'dayjs'
+import { dateFormat } from 'utilities/constants/date-constants'
 
 export function Home() {
-  const { liveGames, scheduledGames, metaData } =
-    useLoaderData<HomeLoaderData>()
+  const { games, metaData } = useLoaderData<HomeLoaderData>()
+
   const revalidator = useRevalidator()
+  const [searchParams, setSearchParams] = useSearchParams()
 
   useEffect(() => {
+    if (!searchParams.get('startDate')) {
+      const startDate = dayjs().format(dateFormat)
+      const endDate = dayjs().add(1, 'week').format(dateFormat)
+
+      setSearchParams({ startDate, endDate })
+    }
+
     const refreshInterval = setInterval(() => {
       if (revalidator.state === 'idle') {
         revalidator.revalidate()
@@ -23,13 +36,12 @@ export function Home() {
     return () => clearInterval(refreshInterval)
   }, [])
 
-  const season = metaData?.scheduled?.season || metaData?.live?.season
+  const season = metaData?.season
 
   return (
     <Box>
-      <GamesCardCarousel games={liveGames} title="Today's Games" />
       <GamesCardCarousel
-        games={scheduledGames}
+        games={games}
         title={
           <ScheduledGamesTitle season={season || dayjs().year().toString()} />
         }

--- a/src/pages/Home/loader.ts
+++ b/src/pages/Home/loader.ts
@@ -19,12 +19,8 @@ export const loader = async ({ request }: LoaderArgs) => {
 
     const gamesRequest = await getGames(year, startDate, endDate)
 
-    const games = gamesRequest.data.filter(
-      (game) => game.date === currentDate.format('ddd MMM DD YYYY')
-    )
-
     return json({
-      games,
+      games: gamesRequest.data,
       metaData: gamesRequest.meta,
     })
   }

--- a/src/pages/Home/loader.ts
+++ b/src/pages/Home/loader.ts
@@ -8,19 +8,27 @@ export type HomeLoaderData = SerializeFrom<typeof loader>
 
 export const loader = async ({ request }: LoaderArgs) => {
   const url = new URL(request.url)
-  const startDate = url.searchParams.get('startDate') || undefined
-  const endDate = url.searchParams.get('endDate') || undefined
-  const currentDate = dayjs().format('ddd MMM DD YYYY')
-  const liveGamesRequest = await getGames()
+  const currentDate = dayjs()
+  const startDate =
+    url.searchParams.get('startDate') || currentDate.format('YYYY-MM-DD')
+  const endDate =
+    url.searchParams.get('endDate') ||
+    currentDate.add(7, 'day').format('YYYY-MM-DD')
+  const year = currentDate.year()
+
+  const liveGamesRequest = await getGames(year, startDate, endDate)
 
   const liveGames = liveGamesRequest.data.filter(
-    (game) => game.date === currentDate
+    (game) => game.date === currentDate.format('ddd MMM DD YYYY')
   )
 
   let scheduledGamesRequest
   let scheduledGames = liveGamesRequest.data
 
-  if ((startDate || endDate) && liveGamesRequest) {
+  if (
+    (url.searchParams.get('startDate') || url.searchParams.get('endDate')) &&
+    liveGamesRequest
+  ) {
     scheduledGamesRequest = await getGames(
       Number.parseInt(liveGamesRequest.meta.season),
       startDate,

--- a/src/pages/Home/loader.ts
+++ b/src/pages/Home/loader.ts
@@ -10,9 +10,9 @@ export const loader = async ({ request }: LoaderArgs) => {
   const url = new URL(request.url)
   const startDate = url.searchParams.get('startDate') || undefined
   const endDate = url.searchParams.get('endDate') || undefined
-  const currentDate = dayjs(new Date().toISOString()).format('ddd MMM DD YYYY')
-
+  const currentDate = dayjs().format('ddd MMM DD YYYY')
   const liveGamesRequest = await getGames()
+
   const liveGames = liveGamesRequest.data.filter(
     (game) => game.date === currentDate
   )

--- a/src/pages/Home/loader.ts
+++ b/src/pages/Home/loader.ts
@@ -8,41 +8,29 @@ export type HomeLoaderData = SerializeFrom<typeof loader>
 
 export const loader = async ({ request }: LoaderArgs) => {
   const url = new URL(request.url)
-  const currentDate = dayjs()
-  const startDate =
-    url.searchParams.get('startDate') || currentDate.format('YYYY-MM-DD')
-  const endDate =
-    url.searchParams.get('endDate') ||
-    currentDate.add(7, 'day').format('YYYY-MM-DD')
-  const year = currentDate.year()
 
-  const liveGamesRequest = await getGames(year, startDate, endDate)
+  const startDate = url.searchParams.get('startDate')
 
-  const liveGames = liveGamesRequest.data.filter(
-    (game) => game.date === currentDate.format('ddd MMM DD YYYY')
-  )
+  const endDate = url.searchParams.get('endDate')
 
-  let scheduledGamesRequest
-  let scheduledGames = liveGamesRequest.data
+  if (startDate && endDate) {
+    const currentDate = dayjs(startDate)
+    const year = currentDate.year()
 
-  if (
-    (url.searchParams.get('startDate') || url.searchParams.get('endDate')) &&
-    liveGamesRequest
-  ) {
-    scheduledGamesRequest = await getGames(
-      Number.parseInt(liveGamesRequest.meta.season),
-      startDate,
-      endDate
+    const gamesRequest = await getGames(year, startDate, endDate)
+
+    const games = gamesRequest.data.filter(
+      (game) => game.date === currentDate.format('ddd MMM DD YYYY')
     )
-    scheduledGames = scheduledGamesRequest.data
+
+    return json({
+      games,
+      metaData: gamesRequest.meta,
+    })
   }
 
   return json({
-    liveGames: liveGames,
-    scheduledGames: scheduledGames,
-    metaData: {
-      live: liveGamesRequest.meta,
-      scheduled: scheduledGamesRequest?.meta,
-    },
+    games: [],
+    metaData: null,
   })
 }

--- a/src/routes/game-stats.$gameId.tsx
+++ b/src/routes/game-stats.$gameId.tsx
@@ -1,2 +1,8 @@
 export { GameStats as default } from '~/pages/GameStats'
 export { loader } from 'src/pages/GameStats/loader'
+
+import statsStyles from '~/css/stats-styles.css'
+
+export function links() {
+  return [{ rel: 'stylesheet', href: statsStyles }]
+}

--- a/utilities/api/dtos.ts
+++ b/utilities/api/dtos.ts
@@ -6,6 +6,7 @@ export type GamesDTO = {
   id: string
   status: string
   date: string
+  time: string
   meta: GamesMetaDataDTO
 }
 

--- a/utilities/api/service.ts
+++ b/utilities/api/service.ts
@@ -12,12 +12,6 @@ import {
 
 import type { GamesDTO, GameStatsDTO } from './dtos'
 
-const currentDate = dayjs()
-const year = currentDate.year()
-
-const defaultStartDate = currentDate.format('YYYY-MM-DD')
-const defaultEndDate = currentDate.add(7, 'day').format('YYYY-MM-DD')
-
 export const isGameLive = (game: GamesDTO) =>
   (<any>Object).values(GameStatus).includes(game.status)
 export const isTime = (time?: string) => time !== '' && !time?.includes('Final')
@@ -137,9 +131,9 @@ const mapGameStatsData = (
 }
 
 export const getGames = async (
-  season = year,
-  startDate: string = defaultStartDate,
-  endDate: string = defaultEndDate
+  season: number,
+  startDate: string,
+  endDate: string
 ): Promise<GameResults> => {
   try {
     const gamesResponse = await fetch(

--- a/utilities/api/service.ts
+++ b/utilities/api/service.ts
@@ -23,14 +23,13 @@ export const isTime = (time?: string) =>
 
 const formatGameTime = (
   date: string,
-  timeLocal?: string,
+  timeLocal: string,
   formatStr?: string
 ) => {
-  const isoTime = String(timeLocal).split(' ').pop()
+  const time = timeLocal.split(' ').shift()
   const isoDate = dayjs(date).toISOString().split('T').shift()
-  const time = isTime(isoTime) ? isoTime : ''
 
-  return dayjs.utc(`${isoDate} ${time}`).format(formatStr)
+  return dayjs(`${isoDate} ${time}`).format(formatStr)
 }
 
 export const mapGamesData = (gamesData: any): GamesDTO[] => {
@@ -51,7 +50,7 @@ export const mapGamesData = (gamesData: any): GamesDTO[] => {
       id: game.id,
       status: game.status as GameStatus | string,
       time: game.time.split(' ').pop(),
-      date: formatGameTime(game.date, game.time, displayDateFormat),
+      date: formatGameTime(game.date, '', displayDateFormat),
     })
   )
 
@@ -61,11 +60,11 @@ export const mapGamesData = (gamesData: any): GamesDTO[] => {
 
     const gameOneTime = formatGameTime(
       gameOne.date,
-      gameOneLive ? '' : gameOne.time
+      gameOneLive ? '' : gameOne.status
     )
     const gameTwoTime = formatGameTime(
       gameTwo.date,
-      gameTwoLive ? '' : gameTwo.time
+      gameTwoLive ? '' : gameTwo.status
     )
 
     if (gameOneTime > gameTwoTime) {
@@ -92,11 +91,7 @@ const mapPlayerStats = (
       teamId: teamStats.team.id,
       game: {
         ...teamStats.game,
-        date: formatGameTime(
-          teamStats.game.date,
-          teamStats.game.time,
-          displayDateFormat
-        ),
+        date: formatGameTime(teamStats.game.date, '', displayDateFormat),
         time: teamStats.game.time?.split(' ').pop(),
       },
       player: {

--- a/utilities/api/service.ts
+++ b/utilities/api/service.ts
@@ -28,7 +28,7 @@ const formatGameTime = (date: string, timeLocal: string) => {
   const time = timeLocal.split(' ').shift()
   const isoDate = new Date(date).toISOString().split('T').shift()
 
-  return dayjs.utc(`${isoDate} ${time}`).format()
+  return dayjs(`${isoDate} ${time}`).format()
 }
 
 export const mapGamesData = (gamesData: any): GamesDTO[] => {
@@ -49,7 +49,7 @@ export const mapGamesData = (gamesData: any): GamesDTO[] => {
       id: game.id,
       status: game.status as GameStatus | string,
       time: game.time,
-      date: dayjs.utc(game.date).format('ddd MMM DD YYYY'),
+      date: dayjs(game.date).format('ddd MMM DD YYYY'),
     })
   )
 
@@ -90,7 +90,7 @@ const mapPlayerStats = (
       teamId: teamStats.team.id,
       game: {
         ...teamStats.game,
-        date: dayjs.utc(teamStats.game.date).format('ddd MMM DD YYYY'),
+        date: dayjs(teamStats.game.date).format('ddd MMM DD YYYY'),
       },
       player: {
         ...teamStats.player,

--- a/utilities/api/service.ts
+++ b/utilities/api/service.ts
@@ -91,6 +91,10 @@ const mapPlayerStats = (
         ...teamStats.game,
         date: dayjs.utc(teamStats.game.date).format('ddd MMM DD YYYY'),
       },
+      player: {
+        ...teamStats.player,
+        full_name: `${teamStats.player.first_name} ${teamStats.player.last_name}`,
+      },
     }))
 
   const leadingStats = stats.find(
@@ -171,7 +175,7 @@ export const getGameStats = async (
     const gameStatsResponseData = await gameStatsResponse.json()
     const { home_team_id, visitor_team_id } =
       gameStatsResponseData.data[0]?.game
-    console.log(home_team_id)
+
     return {
       data: mapGameStatsData(
         gameStatsResponseData.data,

--- a/utilities/api/service.ts
+++ b/utilities/api/service.ts
@@ -48,6 +48,7 @@ export const mapGamesData = (gamesData: any): GamesDTO[] => {
       },
       id: game.id,
       status: game.status as GameStatus | string,
+      time: game.time,
       date: dayjs.utc(game.date).format('ddd MMM DD YYYY'),
     })
   )

--- a/utilities/api/types.ts
+++ b/utilities/api/types.ts
@@ -50,7 +50,7 @@ export type GameStatsData = {
   postseason: boolean
   season: string
   status: string
-  time: string
+  time?: string
   visitor_team_id: string
   visitor_team_score: string
 }

--- a/utilities/constants/date-constants.ts
+++ b/utilities/constants/date-constants.ts
@@ -1,0 +1,2 @@
+export const dateFormat = 'YYYY-MM-DD'
+export const displayDateFormat = 'ddd MMM DD YYYY'


### PR DESCRIPTION
## Description 

A user should be able to view game stats for any specific game. 

## Acceptance Criteria

- [x] User should be able to click on a game card in order to see stats.
- [x] While on `/game-stats` the user should be presented with **Game information** (time + date, team names + score, leading scorers), **Team Stats** (individual player stats per team)
- [x] All data should be live & auto-refresh within `~10mins` (due to current API)
- [x] If no stats are available show N/A message.